### PR TITLE
feat: implement disk store

### DIFF
--- a/.autod.conf.js
+++ b/.autod.conf.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = {
+  write: true,
+  prefix: '^',
+  devprefix: '^',
+  devdep: [
+    'mm',
+    'autod',
+    'egg-ci',
+    'egg-bin',
+    'eslint',
+    'eslint-config-egg'
+  ],
+  test: [
+    'test',
+  ],
+};

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+test/fixtures
+examples/**/app/public
+coverage
+logs
+run

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "eslint-config-egg"
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: false
+language: node_js
+node_js:
+  - '6'
+  - '8'
+install:
+  - npm i npminstall && npminstall
+script:
+  - npm run ci
+after_script:
+  - npminstall codecov && codecov

--- a/README.md
+++ b/README.md
@@ -1,2 +1,63 @@
 # diskstore
-a local cache implement
+a basic local cache implementation
+
+[![NPM version][npm-image]][npm-url]
+[![build status][travis-image]][travis-url]
+[![Test coverage][codecov-image]][codecov-url]
+[![David deps][david-image]][david-url]
+[![Known Vulnerabilities][snyk-image]][snyk-url]
+[![npm download][download-image]][download-url]
+
+[npm-image]: https://img.shields.io/npm/v/diskstore.svg?style=flat-square
+[npm-url]: https://npmjs.org/package/diskstore
+[travis-image]: https://img.shields.io/travis/node-modules/diskstore.svg?style=flat-square
+[travis-url]: https://travis-ci.org/node-modules/diskstore
+[codecov-image]: https://codecov.io/gh/node-modules/diskstore/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/node-modules/diskstore
+[david-image]: https://img.shields.io/david/node-modules/diskstore.svg?style=flat-square
+[david-url]: https://david-dm.org/node-modules/diskstore
+[snyk-image]: https://snyk.io/test/npm/diskstore/badge.svg?style=flat-square
+[snyk-url]: https://snyk.io/test/npm/diskstore
+[download-image]: https://img.shields.io/npm/dm/diskstore.svg?style=flat-square
+[download-url]: https://npmjs.org/package/diskstore
+
+## Introduction
+
+A basic file cache implementation. It just providers low-level APIs (get, set, delete) to allow you read & atomic write from file cache.  You can also create your implementation by inheriting or wrapping it.
+
+## Install
+
+```bash
+$ npm install diskstore --save
+```
+
+## APIs
+
+- `new DiskStore(options)`
+  - {String} cacheDir - root cache dir
+- `* get(relativePath)` read data from relativePath if the file exists.
+  - {String} relativePath - file path relative to root cache dir
+- `* set(relativePath, data)` write data to relativePath
+  - {String} relativePath - file path relative to root cache dir
+  - {Buffer|String} data - the data
+- `* delete(relativePath)` delete the file
+  - {String} relativePath - file path relative to root cache dir
+
+## Usage
+
+```js
+const diskStore = new DiskStore({
+  cacheDir: '/path/cache',
+});
+yield diskStore.set('a/b/c', 'c');
+let data = yield diskStore.get('a/b/c');
+assert.deepEqual(data, new Buffer('c'));
+
+yield diskStore.delete('a/b/c');
+data = yield diskStore.get('a/b/c');
+assert(data === null);
+```
+
+## License
+
+[MIT](LICENSE)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+environment:
+  matrix:
+    - nodejs_version: '6'
+    - nodejs_version: '8'
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - npm i npminstall && node_modules\.bin\npminstall
+
+test_script:
+  - node --version
+  - npm --version
+  - npm run test
+
+build: off

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const fs = require('mz/fs');
+const path = require('path');
+const uuid = require('uuid/v4');
+const Base = require('sdk-base');
+const assert = require('assert');
+const mkdirp = require('mz-modules/mkdirp');
+const rimraf = require('mz-modules/rimraf');
+
+class DiskStore extends Base {
+  /**
+   * disk store
+   * 
+   * @constructor
+   * @param {Object} options
+   *   - {String} cacheDir - cache dir
+   */
+  constructor(options = {}) {
+    assert(options.cacheDir, '[DiskStore] options.cacheDir is required');
+    super(options);
+
+    this.tmpdir = path.join(this.cacheDir, '.tmp');
+    // make sure cache dir to be created
+    mkdirp.sync(this.tmpdir);
+    this.ready(true);
+  }
+
+  get cacheDir() {
+    return this.options.cacheDir;
+  }
+
+  * get(relativePath) {
+    const filepath = path.join(this.cacheDir, relativePath);
+    const isExists = yield fs.exists(filepath);
+    if (!isExists) {
+      return null;
+    }
+    return yield fs.readFile(filepath);
+  }
+
+  * set(relativePath, data) {
+    const filepath = path.join(this.cacheDir, relativePath);
+    // make sure following operations are atomic
+    const dir = path.dirname(filepath);
+    const tmpfile = path.join(this.tmpdir, uuid());
+    yield [
+      mkdirp(dir),
+      mkdirp(this.tmpdir),
+    ];
+
+    yield fs.writeFile(tmpfile, data);
+    try {
+      yield fs.rename(tmpfile, filepath);
+    } catch (err) {
+      yield rimraf(tmpfile);
+      throw err;
+    }
+  }
+
+  * delete(relativePath) {
+    const filepath = path.join(this.cacheDir, relativePath);
+    yield fs.unlink(filepath);
+  }
+}
+
+module.exports = DiskStore;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "diskstore",
+  "version": "1.0.0",
+  "description": "a local cache implement",
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
+  "scripts": {
+    "autod": "autod --check",
+    "pkgfiles": "egg-bin pkgfiles --check",
+    "lint": "eslint --ext .js .",
+    "test": "npm run lint && npm run test-local",
+    "test-local": "egg-bin test",
+    "cov": "egg-bin cov",
+    "ci": "npm run autod && npm run pkgfiles && npm run lint && npm run cov"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/node-modules/diskstore.git"
+  },
+  "keywords": [
+    "cache",
+    "file",
+    "store"
+  ],
+  "author": "gxcsoccer <gxcsoccer@126.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/node-modules/diskstore/issues"
+  },
+  "homepage": "https://github.com/node-modules/diskstore#readme",
+  "dependencies": {
+    "mz": "^2.7.0",
+    "mz-modules": "^2.0.0",
+    "sdk-base": "^3.3.0",
+    "uuid": "^3.1.0"
+  },
+  "devDependencies": {
+    "autod": "^2.10.1",
+    "co": "^4.6.0",
+    "coffee": "^4.1.0",
+    "egg-bin": "^4.3.5",
+    "egg-ci": "^1.8.0",
+    "eslint": "^4.9.0",
+    "eslint-config-egg": "^5.1.1",
+    "mm": "^2.2.0"
+  },
+  "engines": {
+    "node": ">= 6.0.0"
+  },
+  "ci": {
+    "version": "6, 8"
+  }
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const mm = require('mm');
+const fs = require('mz/fs');
+const path = require('path');
+const assert = require('assert');
+const coffee = require('coffee');
+const rimraf = require('mz-modules/rimraf');
+const DiskStore = require('../lib');
+
+const cacheDir = path.join(__dirname, 'tmp');
+
+describe('test/index.test.js', () => {
+  let diskStore;
+  before(function* () {
+    yield rimraf(cacheDir);
+    diskStore = new DiskStore({
+      cacheDir,
+    });
+    yield diskStore.ready();
+  });
+  afterEach(mm.restore);
+  after(function* () {
+    yield rimraf(cacheDir);
+  });
+
+  it('should provide cacheDir', () => {
+    assert.throws(() => {
+      new DiskStore();
+    }, '[DiskStore] options.cacheDir is required');
+  });
+
+  it('should set & get & delete ok', function* () {
+    yield diskStore.set('a', 'a');
+    let data = yield diskStore.get('a');
+    assert.deepEqual(data, new Buffer('a'));
+
+    yield diskStore.delete('a');
+    data = yield diskStore.get('a');
+    assert(data === null);
+  });
+
+  it('should support multi-level folder', function* () {
+    const buf = new Buffer('hello world');
+    yield diskStore.set('a/b/c', buf);
+    let data = yield diskStore.get('a/b/c');
+    assert.deepEqual(data, buf);
+
+    yield diskStore.delete('a/b/c');
+    data = yield diskStore.get('a/b/c');
+    assert(data === null);
+  });
+
+  it('should rm tmpfile anyway', function* () {
+    yield diskStore.set('abc', 'a');
+    let data = yield diskStore.get('abc');
+    assert.deepEqual(data, new Buffer('a'));
+    mm(fs, 'rename', () => {
+      return Promise.reject(new Error('mock error'));
+    });
+    try {
+      yield diskStore.set('abc', 'b');
+      assert(false, 'should not run here');
+    } catch (err) {
+      assert(err.message === 'mock error');
+    }
+    data = yield diskStore.get('abc');
+    assert.deepEqual(data, new Buffer('a'));
+    const files = yield fs.readdir(path.join(cacheDir, '.tmp'));
+    assert(files.length === 0);
+  });
+
+  describe('write atomic', () => {
+    it('should write be atomic', function* () {
+      yield coffee.fork('write_big_file.js', [])
+        .expect('code', 1)
+        .end();
+
+      const isExists = yield fs.exists(path.join(cacheDir, 'big.bin'));
+      assert(!isExists);
+    });
+  });
+});

--- a/test/write_big_file.js
+++ b/test/write_big_file.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const co = require('co');
+const path = require('path');
+const DiskStore = require('../');
+const cacheDir = path.join(__dirname, 'tmp');
+
+const store = new DiskStore({ cacheDir });
+
+co(function* () {
+
+  console.time('write');
+  yield store.set('big.bin', new Buffer(50 * 1024 * 1024));
+  console.timeEnd('write');
+
+}).catch(err => {
+  console.error(err);
+});
+
+setTimeout(() => {
+  process.exit(1);
+}, 5);


### PR DESCRIPTION
## Introduction

A basic file cache implementation. It just providers low-level APIs (get, set, delete) to allow you read & atomic write from file cache.  You can also create your implementation by inheriting or wrapping it.

## Install

```bash
$ npm install diskstore --save
```

## APIs

- `new DiskStore(options)`
  - {String} cacheDir - root cache dir
- `* get(relativePath)` read data from relativePath if the file exists.
  - {String} relativePath - file path relative to root cache dir
- `* set(relativePath, data)` write data to relativePath
  - {String} relativePath - file path relative to root cache dir
  - {Buffer|String} data - the data
- `* delete(relativePath)` delete the file
  - {String} relativePath - file path relative to root cache dir

## Usage

```js
const diskStore = new DiskStore({
  cacheDir: '/path/cache',
});
yield diskStore.set('a/b/c', 'c');
let data = yield diskStore.get('a/b/c');
assert.deepEqual(data, new Buffer('c'));

yield diskStore.delete('a/b/c');
data = yield diskStore.get('a/b/c');
assert(data === null);
```